### PR TITLE
Fix of db wrapper

### DIFF
--- a/server/src/database.ts
+++ b/server/src/database.ts
@@ -1,12 +1,10 @@
 import { Pool, QueryResult } from "pg";
 import { strict as assert } from "assert";
 
-let pool: Pool;
-let connected: boolean | undefined;
+let pool: Pool | undefined;
 
 export class Database {
   static setup() {
-    assert(connected === undefined);
     pool = new Pool({
       host: process.env.DB_HOST,
       port: process.env.DB_PORT ? parseInt(process.env.DB_PORT) : 5432,
@@ -14,25 +12,17 @@ export class Database {
       password: process.env.DB_PASSWORD,
       database: process.env.DB_NAME,
     });
-    connected = false;
-  }
-
-  static async connect(): Promise<void> {
-    if (connected === undefined) Database.setup();
-    assert(connected === false);
-    await pool.connect();
-    connected = true;
   }
 
   static async disconnect(): Promise<void> {
-    assert(connected === true);
+    assert(pool);
     await pool.end();
-    connected = false;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   static async query(text: string, values?: any[]): Promise<QueryResult<any>> {
-    if (!connected) await Database.connect();
+    if (!pool) Database.setup();
+    assert(pool);
     return await pool.query(text, values);
   }
 }


### PR DESCRIPTION
Initially I thought connect was required to query the Pool. @emanuelefrisi pointed out correctly that I started making the wrapper without full understanding of the docs.

What I thought:

pool.connect()
// use the pool
pool.end()

How it actually should be used:

const p = new Pool(config)
// use the pool
pool.end()