### PR TITLE
Api docs

### DIFF
--- a/API documentation.md
+++ b/API documentation.md
@@ -57,7 +57,7 @@ TODO: filters
           "latitude": 67.85624725739333,
           "longitude": 20.23857657264496
         },
-        "issuanceDate": "2024-11-08T19:55:00+01:00",
+        "issuanceDate": "2024-11-08",
         "links": [
             {
                 "targetDocumentId": 2,
@@ -102,7 +102,7 @@ Retrieve a specific document by its unique identifier.
       "latitude": 67.85624725739333,
       "longitude": 20.23857657264496
     },
-    "issuanceDate": "2024-11-08T19:55:00+01:00",
+    "issuanceDate": "2024-11-08",
     "links": [
         {
             "targetDocumentId": 2,
@@ -143,7 +143,7 @@ Create a new document.
 | `coordinates`           | Object containing geographical data                                                | `object`            | No                             |
 | `coordinates.latitude`  | Value in the range [-90, +90] degrees                                              | `number`            | Yes if `longitude` is provided |
 | `coordinates.longitude` | Value in the range [-180, +180] degrees                                            | `number`            | Yes if `latitude` is provided  |
-| `issuanceDate`          | Issuance date of the document                                                      | `string`            | No                             |
+| `issuanceDate`          | UTC date (format: `YYYY-MM-DD`)                                                    | `string`            | No                             |
 
 ### Request body
 
@@ -161,7 +161,7 @@ Create a new document.
     "latitude": 67.85624725739333,
     "longitude": 20.23857657264496
   },
-  "issuanceDate": "2024-11-08T19:55:00+01:00"
+  "issuanceDate": "2024-11-08"
 }
 ```
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "cors": "^2.8.5",
         "cross-env": "^7.0.3",
+        "dayjs": "^1.11.13",
         "dotenv": "^16.4.5",
         "express": "^4.21.1",
         "express-session": "^1.18.1",
@@ -2976,6 +2977,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg=="
     },
     "node_modules/debug": {
       "version": "2.6.9",

--- a/server/package.json
+++ b/server/package.json
@@ -25,8 +25,8 @@
     "@types/morgan": "^1.9.9",
     "@types/passport-local": "^1.0.38",
     "@types/pg": "^8.11.10",
-    "bcrypt": "^5.1.1",
     "@types/supertest": "^6.0.2",
+    "bcrypt": "^5.1.1",
     "eslint": "^9.13.0",
     "eslint-config-prettier": "^9.1.0",
     "jest": "^29.7.0",
@@ -41,6 +41,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "cross-env": "^7.0.3",
+    "dayjs": "^1.11.13",
     "dotenv": "^16.4.5",
     "express": "^4.21.1",
     "express-session": "^1.18.1",

--- a/server/src/model/document.ts
+++ b/server/src/model/document.ts
@@ -3,7 +3,7 @@ import { Database } from "../database";
 import { DocumentNotFound } from "../error/documentError";
 import { Coordinates } from "../validation/documentSchema";
 import { Scale, ScaleType, ScaleRow } from "./scale";
-import dayjs, { Dayjs } from "dayjs";
+import { Dayjs } from "dayjs";
 
 type DocumentDbRow = {
   id: number;

--- a/server/src/model/document.ts
+++ b/server/src/model/document.ts
@@ -74,14 +74,15 @@ export class Document {
       coordinates,
       issuanceDate,
     } = dbRow;
+    assert(typeof title === "string");
+    assert(typeof description === "string");
+    assert(typeof type === "string");
+    assert(typeof scale_type === "string");
+
     const scale: Scale = Scale.fromDatabaseRow({
       scale_type,
       scale_ratio,
     } as ScaleRow);
-    assert(typeof title === "string");
-    assert(typeof description === "string");
-    assert(typeof scale === "string");
-    assert(typeof type === "string");
 
     return new Document(
       id,
@@ -89,9 +90,9 @@ export class Document {
       description,
       type,
       scale,
-      stakeholders,
-      coordinates.latitude && coordinates.longitude ? coordinates : undefined,
-      issuanceDate,
+      stakeholders || undefined,
+      coordinates || undefined,
+      issuanceDate || undefined,
     );
   }
 
@@ -135,8 +136,8 @@ export class Document {
         scaleRow.scale_type,
         scaleRow.scale_ratio || null,
         stakeholders || null,
-        coordinates || null,
-        coordinates || null,
+        coordinates?.longitude || null,
+        coordinates?.latitude || null,
         issuance_date || null,
       ],
     );
@@ -175,8 +176,10 @@ export class Document {
       FROM document WHERE id = $1`,
       [id],
     );
+    if (result.rowCount != 1) {
+      throw new DocumentNotFound();
+    }
     const documentRow = result.rows[0];
-
     return Document.fromDatabaseRow(documentRow);
   }
 }

--- a/server/src/model/scale.ts
+++ b/server/src/model/scale.ts
@@ -4,7 +4,7 @@ export type ScaleRow = {
 };
 
 export enum ScaleType {
-  BlueprintsOrEffect = "blueprints/effect",
+  BlueprintsOrEffect = "blueprints/effects",
   Text = "text",
   Ratio = "ratio",
 }

--- a/server/src/model/scale.ts
+++ b/server/src/model/scale.ts
@@ -1,0 +1,31 @@
+export type ScaleRow = {
+  scale_type: ScaleType;
+  scale_ratio: number | null;
+};
+
+export enum ScaleType {
+  BlueprintsOrEffect = "BLUEPRINTS/EFFECT",
+  Text = "TEXT",
+  Ratio = "RATIO",
+}
+
+export class Scale {
+  type: ScaleType;
+  ratio?: number;
+
+  constructor(type: ScaleType, ratio: number | undefined) {
+    this.type = type;
+    this.ratio = ratio;
+  }
+
+  static fromDatabaseRow(row: ScaleRow): Scale {
+    return new Scale(row.scale_type, row.scale_ratio || undefined);
+  }
+
+  intoDatabaseRow(): ScaleRow {
+    return {
+      scale_type: this.type,
+      scale_ratio: this.ratio || null,
+    };
+  }
+}

--- a/server/src/model/scale.ts
+++ b/server/src/model/scale.ts
@@ -4,9 +4,9 @@ export type ScaleRow = {
 };
 
 export enum ScaleType {
-  BlueprintsOrEffect = "BLUEPRINTS/EFFECT",
-  Text = "TEXT",
-  Ratio = "RATIO",
+  BlueprintsOrEffect = "blueprints/effect",
+  Text = "text",
+  Ratio = "ratio",
 }
 
 export class Scale {

--- a/server/src/validation/documentSchema.ts
+++ b/server/src/validation/documentSchema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
-import { DocumentType, Scale } from "../model/document";
+import { DocumentType, Stakeholder } from "../model/document";
+import { ScaleType } from "../model/scale";
 
 export type Coordinates = z.infer<typeof coordinates>;
 const coordinates = z
@@ -13,15 +14,22 @@ export const idRequestParam = z.object({
   id: z.coerce.number().min(1),
 });
 
+export type Scale = z.infer<typeof scale>;
+const scale = z.object({
+  type: z.nativeEnum(ScaleType),
+  ratio: z.number().optional(), //TODO: refine
+});
+
 export type PostBody = z.infer<typeof postBody>;
 export const postBody = z
   .object({
     title: z.string().min(1),
     description: z.string().min(1),
-    coordinates: coordinates,
-    scale: z.nativeEnum(Scale),
     type: z.nativeEnum(DocumentType),
-    language: z.string(),
+    scale,
+    stakeholders: z.array(z.nativeEnum(Stakeholder)),
+    coordinates: coordinates,
+    issuanceDate: z.coerce.date(), //TODO:
   })
   .strict();
 
@@ -30,7 +38,10 @@ export const patchBody = z
   .object({
     title: z.string().min(1).optional(),
     description: z.string().min(1).optional(),
-    coordinates: coordinates.optional(),
     type: z.nativeEnum(DocumentType).optional(),
+    scale: scale.optional(),
+    stakeholders: z.array(z.nativeEnum(Stakeholder)).optional(),
+    coordinates: coordinates.optional(),
+    issuanceDate: z.coerce.date().optional(), //TODO:
   })
   .strict();

--- a/server/src/validation/documentSchema.ts
+++ b/server/src/validation/documentSchema.ts
@@ -27,9 +27,9 @@ export const postBody = z
     description: z.string().min(1),
     type: z.nativeEnum(DocumentType),
     scale,
-    stakeholders: z.array(z.nativeEnum(Stakeholder)),
-    coordinates: coordinates,
-    issuanceDate: z.coerce.date(), //TODO:
+    stakeholders: z.array(z.nativeEnum(Stakeholder)).optional(),
+    coordinates: coordinates.optional(),
+    issuanceDate: z.coerce.date().optional(), //TODO:
   })
   .strict();
 

--- a/server/test/documentRouter.test.ts
+++ b/server/test/documentRouter.test.ts
@@ -4,7 +4,8 @@ import app from "../src/app";
 import request from "supertest";
 import { StatusCodes } from "http-status-codes";
 import { Database } from "../src/database";
-import { DocumentType, Scale } from "../src/model/document";
+import { DocumentType } from "../src/model/document";
+import { ScaleType } from "../src/model/scale";
 import { loginAsPlanner } from "./utils";
 
 let plannerCookie: string;
@@ -67,8 +68,8 @@ describe("Testing with coordinates", () => {
   const testDoc = {
     title: "Coordinates test",
     description: "This one will be tested with coordinates",
-    scale: Scale.BlueprintsEffects,
     type: DocumentType.Informative,
+    scale: { type: ScaleType.BlueprintsOrEffect },
   };
   const wrongCoordinates = {
     latitude: 120,


### PR DESCRIPTION
My proposal is for the API to communicate dates in UTC format.
If a one of /documents is PATCHed with issueDate: "2024-01-01" this means it was issued in any timestamp:
- after 2024-01-01T00:00:00.000Z
- before 2024-01-02T00:00:00.000Z
where these two are UTC dates (Z means english Grwch time)