### PR TITLE
Scale value bug fixed

### DIFF
--- a/server/src/validation/documentSchema.ts
+++ b/server/src/validation/documentSchema.ts
@@ -15,10 +15,21 @@ export const idRequestParam = z.object({
 });
 
 export type Scale = z.infer<typeof scale>;
-const scale = z.object({
-  type: z.nativeEnum(ScaleType),
-  ratio: z.number().optional(), //TODO: refine
-});
+const scale = z
+  .object({
+    type: z.nativeEnum(ScaleType),
+    ratio: z.number().optional(),
+  })
+  .strict()
+  .superRefine((data, ctx) => {
+    if (data.type === ScaleType.Ratio && data.ratio === undefined) {
+      ctx.addIssue({
+        path: ["value"],
+        message: "scale.value is required when scale.type is Ratio",
+        code: z.ZodIssueCode.custom,
+      });
+    }
+  });
 
 export type PostBody = z.infer<typeof postBody>;
 export const postBody = z


### PR DESCRIPTION
Now if a `POST /documents` is requested with a scale.type=ratio but without a scale.ratio property in the request body, the server will return a 400 error