### PR TITLE
Add validation to prevent self linking of documents

### DIFF
--- a/server/src/middleware/validation.ts
+++ b/server/src/middleware/validation.ts
@@ -2,6 +2,7 @@ import { Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { StatusCodes } from "http-status-codes";
 import { ParamsDictionary } from "express-serve-static-core";
+import { PutBody as LinkPutBody } from "../validation/linkSchema";
 
 // Alternative: https://dev.to/osalumense/validating-request-data-in-expressjs-using-zod-a-comprehensive-guide-3a0j#:~:text=import%20%7B%20RequestHandler%20%7D%20from%20%27express%27%3B
 
@@ -24,3 +25,22 @@ export const validateRequestParameters = createValidator(
 export const validateQueryParameters = createValidator(
   (request: Request) => request.query as ParamsDictionary,
 );
+
+/**
+ * This middleware checks that the document id in the request parameter
+ * is different from the targetDocumentId in the request body
+ * to prevent linking a document with itself
+ */
+export const checkSelfLink = (
+  request: Request,
+  response: Response,
+  nextFunction: NextFunction,
+) => {
+  const { targetDocumentId } = request.body as LinkPutBody;
+  const sourceDocumentId = Number(request.params.id);
+  if (sourceDocumentId == targetDocumentId) {
+    response.status(StatusCodes.BAD_REQUEST).send();
+    return;
+  }
+  nextFunction();
+};

--- a/server/src/router/linkRouter.ts
+++ b/server/src/router/linkRouter.ts
@@ -2,6 +2,7 @@ import { Request, Response, Router } from "express";
 import { Link, LinkResponseBody } from "../model/link";
 import { StatusCodes } from "http-status-codes";
 import {
+  checkSelfLink,
   validateBody,
   validateQueryParameters,
   validateRequestParameters,
@@ -30,6 +31,7 @@ linkRouter.put(
   isPlanner,
   validateRequestParameters(idRequestParam),
   validateBody(putBody),
+  checkSelfLink,
   async (request: Request, response: Response) => {
     const sourceDocumentId = Number(request.params.id);
     const body = request.body as PutBody;

--- a/server/test/selfLink.test.ts
+++ b/server/test/selfLink.test.ts
@@ -1,0 +1,44 @@
+import { StatusCodes } from "http-status-codes";
+import { Database } from "../src/database";
+import { loginAsPlanner } from "./utils";
+import { DocumentType } from "../src/model/document";
+import { ScaleType } from "../src/model/scale";
+import { LinkType } from "../src/model/link";
+import app from "../src/app";
+import request from "supertest";
+
+let plannerCookie: string;
+const document = {
+  title: "Self link",
+  description: "Created to test self linking bad requests",
+  type: DocumentType.Prescriptive,
+  scale: { type: ScaleType.Text },
+};
+
+beforeAll(async () => {
+  plannerCookie = await loginAsPlanner();
+});
+
+afterAll(async () => {
+  await Database.disconnect();
+});
+
+test("Linking a document with itself should return a BAD_REQUEST", async () => {
+  let response = await request(app)
+    .post("/documents")
+    .set("Cookie", plannerCookie)
+    .send(document);
+  expect(response.status).toStrictEqual(StatusCodes.CREATED);
+  const { id } = response.body;
+  expect(id).toBeDefined();
+  expect(typeof id).toBe("number");
+  response = await request(app)
+    .put(`/documents/${id}/links`)
+    .set("Cookie", plannerCookie)
+    .send({
+      targetDocumentId: id,
+      linkTypes: [LinkType.Collateral, LinkType.Direct],
+    });
+  expect(response.status).toStrictEqual(StatusCodes.BAD_REQUEST);
+  await request(app).del(`/documents/${id}`);
+});


### PR DESCRIPTION
This PR fixes issue #66 raised by @emanuelefrisi  adding:
- a new validation middleware which prevents self linking
- application of said middleware to the link router
- one test case for this issue