### PR TITLE
Edit GET /uploads to allow getting decoupled uploads

### DIFF
--- a/API documentation.md
+++ b/API documentation.md
@@ -524,11 +524,6 @@ This API uses the following error codes:
 - `404 Not Found`: The requested upload was not found.
 - `500 Internal Server Error`: An unexpected error occurred on the server.
 
-# <<<<<<< Updated upstream
-
-> > > > > > > Stashed changes
-> > > > > > > Stashed changes
-
 # Collection `sessions`
 
 Handles user session management.

--- a/API documentation.md
+++ b/API documentation.md
@@ -372,7 +372,7 @@ This API uses the following error codes:
 
 ### Query parameters
 
-- `documentId`: **mandatory**. Returns uploads related to this document only.
+- `documentId`: **mandatory** when file=include. Returns uploads related to this document only.
 - `file`: defaults to `omit` to return uploads metadata only or `include` to return metadata along with the file.
 
 ### Response body
@@ -523,6 +523,11 @@ This API uses the following error codes:
 - `401 Unauthorized`: You are unauthorized.
 - `404 Not Found`: The requested upload was not found.
 - `500 Internal Server Error`: An unexpected error occurred on the server.
+
+# <<<<<<< Updated upstream
+
+> > > > > > > Stashed changes
+> > > > > > > Stashed changes
 
 # Collection `sessions`
 

--- a/server/src/model/upload.ts
+++ b/server/src/model/upload.ts
@@ -57,14 +57,16 @@ export class Upload {
   }
 
   static async fromDocumentAll(
-    documentId: number,
+    documentId?: number,
     includeFile: boolean = false,
   ): Promise<Upload[]> {
-    const sql = `SELECT u.id, u.title, u.type${includeFile ? ", file" : ""} 
-      FROM document d 
-      JOIN upload u ON u.id = ANY(d.upload_ids) 
-      WHERE d.id = $1`;
-    const result = await Database.query(sql, [documentId]);
+    const joinSql = `JOIN document d ON u.id = ANY(d.upload_ids) 
+      ${documentId ? "WHERE d.id = $1" : ""}`;
+    const sql = `SELECT u.id, u.title, 
+      u.type${includeFile ? ", file" : ""} 
+      FROM upload u ${documentId ? joinSql : ""}`;
+    const args = documentId ? [documentId] : [];
+    const result = await Database.query(sql, args);
     return result.rows.map(
       ({ id, title, type, file }) => new Upload(id, title, type, file),
     );

--- a/server/src/router/uploadRouter.ts
+++ b/server/src/router/uploadRouter.ts
@@ -24,8 +24,9 @@ uploadRouter.get(
   "/",
   validateQueryParameters(getManyQueryParameters),
   async (request: Request, response: Response, next: NextFunction) => {
-    const documentId = Number(request.query.documentId);
-    const includeFile = request.query.file === "include";
+    const { documentId: rawId, file } = request.query;
+    const documentId = rawId ? Number(rawId) : undefined;
+    const includeFile = file === "include";
     const uploads = await Upload.fromDocumentAll(documentId, includeFile);
     response
       .status(StatusCodes.OK)

--- a/server/src/validation/uploadSchema.ts
+++ b/server/src/validation/uploadSchema.ts
@@ -20,10 +20,11 @@ export const postBody = z
 export type GetManyQueryParameters = z.infer<typeof getManyQueryParameters>;
 export const getManyQueryParameters = z
   .object({
-    documentId: z.coerce.number().int().positive(),
+    documentId: z.coerce.number().int().positive().optional(),
     file: z.literal("omit").or(z.literal("include")).optional(),
   })
-  .strict();
+  .strict()
+  .refine((query) => !(query.documentId && query.file === "include"));
 
 //TODO: refine at least one field must be defined
 //TODO: refine intersection of ids in bind and decouple must be empty

--- a/server/src/validation/uploadSchema.ts
+++ b/server/src/validation/uploadSchema.ts
@@ -24,7 +24,7 @@ export const getManyQueryParameters = z
     file: z.literal("omit").or(z.literal("include")).optional(),
   })
   .strict()
-  .refine((query) => !(query.documentId && query.file === "include"));
+  .refine((query) => query.documentId || query.file !== "include");
 
 //TODO: refine at least one field must be defined
 //TODO: refine intersection of ids in bind and decouple must be empty

--- a/server/test/uploadRouter.test.ts
+++ b/server/test/uploadRouter.test.ts
@@ -1,11 +1,6 @@
 import { StatusCodes } from "http-status-codes";
 import request from "supertest";
 import app from "../src/app";
-import { Database } from "../src/database";
-
-afterAll(async () => {
-  await Database.disconnect();
-});
 
 describe("Upload bad requests", () => {
   test("File=include without a documentId is a BAD_REQUEST", async () => {

--- a/server/test/uploadRouter.test.ts
+++ b/server/test/uploadRouter.test.ts
@@ -1,0 +1,15 @@
+import { StatusCodes } from "http-status-codes";
+import request from "supertest";
+import app from "../src/app";
+import { Database } from "../src/database";
+
+afterAll(async () => {
+  await Database.disconnect();
+});
+
+describe("Upload bad requests", () => {
+  test("File=include without a documentId is a BAD_REQUEST", async () => {
+    const response = await request(app).get("/uploads/?file=include");
+    expect(response.status).toStrictEqual(StatusCodes.BAD_REQUEST);
+  });
+});


### PR DESCRIPTION
Now it's allowed to GET /uploads without providing a documentId.
When a documentId is not provided the metadata of all the uploads is returned