### PR TITLE
Check for valid relation between min and max date

### DIFF
--- a/server/src/middleware/error.ts
+++ b/server/src/middleware/error.ts
@@ -1,4 +1,4 @@
-import { Request, Response, NextFunction } from "express";
+import { NextFunction, Request, Response } from "express";
 import { StatusCodes } from "http-status-codes";
 import { UserError } from "../error/userError";
 
@@ -7,18 +7,22 @@ import { UserError } from "../error/userError";
  * it handles unhandled errors
  */
 export function sinkErrorHandler(
-  err: Error,
+  error: Error,
   request: Request,
   response: Response,
   next: NextFunction,
 ) {
-  if (err instanceof UserError) {
-    response.status(err.statusCode).json({ message: err.message });
+  if (response.headersSent) {
+    next(error);
+    return;
+  }
+  if (error instanceof UserError) {
+    response.status(error.statusCode).json({ message: error.message });
   } else {
-    console.error(err);
+    console.error(error);
     response
       .status(StatusCodes.INTERNAL_SERVER_ERROR)
       .json({ message: "An unexpected error occurred on the server" });
   }
-  next();
+  next(error);
 }

--- a/server/src/middleware/validation.ts
+++ b/server/src/middleware/validation.ts
@@ -10,11 +10,12 @@ const createValidator =
   (targetExtractor = (request: Request) => request.body) =>
   (schema: z.Schema) =>
   (request: Request, response: Response, nextFunction: NextFunction) => {
-    const { success } = schema.safeParse(targetExtractor(request));
-    if (success) {
+    const parseResult = schema.safeParse(targetExtractor(request));
+    if (parseResult.success) {
       nextFunction();
     } else {
-      response.status(StatusCodes.BAD_REQUEST).send();
+      response.status(StatusCodes.BAD_REQUEST).send(parseResult.error);
+      nextFunction(parseResult.error);
     }
   };
 

--- a/server/test/documentRouter.test.ts
+++ b/server/test/documentRouter.test.ts
@@ -1,12 +1,12 @@
 import dotenv from "dotenv";
-dotenv.config(); //TODO: remove and fix
-import app from "../src/app";
-import request from "supertest";
 import { StatusCodes } from "http-status-codes";
+import request from "supertest";
+import app from "../src/app";
 import { Database } from "../src/database";
 import { DocumentType } from "../src/model/document";
 import { ScaleType } from "../src/model/scale";
 import { loginAsPlanner } from "./utils";
+dotenv.config(); //TODO: remove and fix
 
 let plannerCookie: string;
 
@@ -116,5 +116,21 @@ describe("Testing with coordinates", () => {
       .del(`/documents/${testDocId}`)
       .set("Cookie", plannerCookie);
     expect(response.status).toStrictEqual(StatusCodes.NO_CONTENT);
+  });
+});
+
+describe("GET /documents filters", () => {
+  test("minIssuanceDate > maxIssuanceDate is a bad request", async () => {
+    const response = await request(app).get(
+      `/documents/?minIssuanceDate=2024-01-01&maxIssuanceDate=2023-12-31`,
+    );
+    expect(response.status).toStrictEqual(StatusCodes.BAD_REQUEST);
+  });
+
+  test("minIssuanceDate == maxIssuanceDate is a valid request", async () => {
+    const response = await request(app).get(
+      `/documents/?minIssuanceDate=2024-01-01&maxIssuanceDate=2024-01-01`,
+    );
+    expect(response.status).toStrictEqual(StatusCodes.OK);
   });
 });


### PR DESCRIPTION
This PR fixes issue #138 . Enforcing that minIssuanceDate is always smaller or equal to maxIssuanceDate, if both are given.